### PR TITLE
Add missing library and fixed minor issue

### DIFF
--- a/.classpath
+++ b/.classpath
@@ -19,8 +19,9 @@
 		</attributes>
 	</classpathentry>
 	<classpathentry kind="con" path="org.eclipse.pde.core.requiredPlugins"/>
-	<classpathentry kind="src" path="src/"/>
+	<classpathentry kind="src" path="src"/>
 	<classpathentry exported="true" kind="lib" path="lib/library-2.10.0.jar"/>
 	<classpathentry exported="true" kind="lib" path="lib/validator-2.10.0.jar"/>
+	<classpathentry kind="lib" path="lib/fontbox-2.0.30.jar"/>
 	<classpathentry kind="output" path="bin"/>
 </classpath>

--- a/META-INF/MANIFEST.MF
+++ b/META-INF/MANIFEST.MF
@@ -11,7 +11,7 @@ Require-Bundle: org.adempiere.base;bundle-version="8.2.0",
  com.sun.activation.jakarta.activation;bundle-version="1.2.2",
  wrapped.org.dom4j.dom4j;bundle-version="2.1.3",
  org.apache.commons.logging;bundle-version="1.2.0",
- org.adempiere.ui.zk;bundle-version="12.0.0",
+ org.adempiere.ui.zk;bundle-version="11.0.0",
  zk
 Service-Component: OSGI-INF/*.xml
 Import-Package: javax.xml.transform,
@@ -45,6 +45,7 @@ Bundle-ClassPath: .,
  lib/batik-all-1.17.jar,
  lib/xmpbox-2.0.30.jar,
  lib/pdfbox-2.0.30.jar,
- lib/preflight-2.0.30.jar
+ lib/preflight-2.0.30.jar,
+ lib/fontbox-2.0.30.jar
 Bundle-ActivationPolicy: lazy
 Bundle-Activator: org.adempiere.plugin.utils.Incremental2PackActivator

--- a/build.properties
+++ b/build.properties
@@ -17,7 +17,8 @@ bin.includes = META-INF/,\
                lib/batik-all-1.17.jar,\
                lib/xmpbox-2.0.30.jar,\
                lib/pdfbox-2.0.30.jar,\
-               lib/preflight-2.0.30.jar
+               lib/preflight-2.0.30.jar,\
+               lib/fontbox-2.0.30.jar
 source.. = src/
 src.includes = ReadMe.md,\
                OSGI-INF/,\

--- a/pom.xml
+++ b/pom.xml
@@ -58,6 +58,11 @@
 						<version>2.0.30</version>
 						</artifactItem>
 						<artifactItem>
+							<groupId>org.apache.pdfbox</groupId>
+							<artifactId>fontbox</artifactId>
+							<version>2.0.30</version>
+						</artifactItem>
+						<artifactItem>
     						<groupId>net.sf.saxon</groupId>
     						<artifactId>Saxon-HE</artifactId>
     						<version>12.4</version>


### PR DESCRIPTION
Additionally, I changed this line
org.adempiere.ui.zk;bundle-version="12.0.0",
for 
org.adempiere.ui.zk;bundle-version="11.0.0",

otherwise the plug-in does not run in iDempiere 11
--------------------------
When running the process, the following error is thrown:

13:59:47.273===========> ZUGFeRD.process: org/apache/fontbox/FontBoxFont [210]
java.lang.ClassNotFoundException: org.apache.fontbox.FontBoxFont cannot be found by auler.gmbh.zugferdxinvoice_10.0.0.202409111353
at org.eclipse.osgi.internal.loader.BundleLoader.generateException(BundleLoader.java:541)
at org.eclipse.osgi.internal.loader.BundleLoader.findClass0(BundleLoader.java:536)
at org.eclipse.osgi.internal.loader.BundleLoader.findClass(BundleLoader.java:416)
at org.eclipse.osgi.internal.loader.ModuleClassLoader.loadClass(ModuleClassLoader.java:168)
at java.base/java.lang.ClassLoader.loadClass(ClassLoader.java:525)
at org.apache.pdfbox.pdmodel.font.PDFontFactory.createFont(PDFontFactory.java:76)
at org.apache.pdfbox.pdmodel.PDResources.getFont(PDResources.java:171)
at org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3.removeCidSet(ZUGFeRDExporterFromA3.java:548)
at org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3.prepareDocument(ZUGFeRDExporterFromA3.java:574)
at org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3.prepare(ZUGFeRDExporterFromA3.java:617)
at org.mustangproject.ZUGFeRD.ZUGFeRDExporterFromA3.setTransaction(ZUGFeRDExporterFromA3.java:613)
at auler.gmbh.zugferdxinvoice.process.ZUGFeRD.createInvoice(ZUGFeRD.java:353)
at auler.gmbh.zugferdxinvoice.process.ZUGFeRD.doIt(ZUGFeRD.java:120)
