### PR TITLE
Add missing bin exports

### DIFF
--- a/build.properties
+++ b/build.properties
@@ -1,7 +1,7 @@
 output.. = bin/
 bin.includes = META-INF/,\
                .,\
-               OSGI-INF/processdef.xml,\
+               OSGI-INF/,\
                lib/library-2.10.0.jar,\
                lib/validator-2.10.0.jar,\
                COPYING,\


### PR DESCRIPTION
When deploying in a remote server the toolbar button is not displayed because the OSGI pat_toolbaraction.xml is not exported